### PR TITLE
:bug: Fixed API request URL for Windows users, resolves using docker …

### DIFF
--- a/app/frontend/.env
+++ b/app/frontend/.env
@@ -1,1 +1,1 @@
-REACT_APP_URL="http://0.0.0.0:8000/"
+REACT_APP_URL="http://host.docker.internal:8000"


### PR DESCRIPTION
# Bugs

- Error while testing for Windows using WSL
- API endpoints working fine with `http:0.0.0.0:8000/` but was not being accessible from frontend

## Fixes:
- Updated `.env` in frontend to resolve with docker internal network
```
REACT_APP_URL="http://host.docker.internal:8000"
````